### PR TITLE
Make privateKey Secret. Allow empty privateKey.

### DIFF
--- a/src/main/java/jenkins/plugins/rpmsign/GpgKey.java
+++ b/src/main/java/jenkins/plugins/rpmsign/GpgKey.java
@@ -12,14 +12,14 @@ public class GpgKey implements Serializable {
   private transient String id;
 
   private String name;
-  private String privateKey;
+  private Secret privateKey;
   private Secret passphrase;
 
   public GpgKey() {
   }
 
   @DataBoundConstructor
-  public GpgKey(String name, String privateKey, Secret passphrase) {
+  public GpgKey(String name, Secret privateKey, Secret passphrase) {
     this.name = name;
     this.privateKey = privateKey;
     this.passphrase = passphrase;
@@ -33,12 +33,12 @@ public class GpgKey implements Serializable {
 
   public int getUniqueId() {
     int result = name != null ? name.hashCode() : 0;
-    result = 31 * result + privateKey != null ? privateKey.hashCode() : 0;
+    result = 31 * result + (privateKey.getPlainText() != null ? privateKey.getPlainText().hashCode() : 0);
     result = 31 * result + (passphrase.getPlainText() != null ? passphrase.getPlainText().hashCode() : 0);
     return result;
   }
 
-  public String getPrivateKey() {
+  public Secret getPrivateKey() {
     return privateKey;
   }
 

--- a/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
+++ b/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
@@ -69,13 +69,10 @@ public class RpmSignPlugin extends Recorder {
         StringTokenizer rpmGlobTokenizer = new StringTokenizer(rpmEntry.getIncludes(), ",");
 
         GpgKey gpgKey = getGpgKey(rpmEntry.getGpgKeyName());
-        if (gpgKey != null) {
-          listener.getLogger().println("[RpmSignPlugin] - Importing private key");
-          importGpgKey(gpgKey.getPrivateKey(), build, launcher, listener);
-          listener.getLogger().println("[RpmSignPlugin] - Imported private key");
-        } else {
-          listener.getLogger().println("[RpmSignPlugin] - Can't find GPG key: " + rpmEntry.getGpgKeyName());
-          return false;
+        if (gpgKey != null && gpgKey.getPrivateKey().getPlainText().length() > 0) {
+            listener.getLogger().println("[RpmSignPlugin] - Importing private key");
+            importGpgKey(gpgKey.getPrivateKey().getPlainText(), build, launcher, listener);
+            listener.getLogger().println("[RpmSignPlugin] - Imported private key");
         }
         
         if (!isGpgKeyAvailable(gpgKey, build, launcher, listener)){


### PR DESCRIPTION
If privateKey doesn't exist or has length 0, don't import it.
User instead should import it with command line tools.
