### PR TITLE
Updates for rpm version 4.12.0.1-11 from RedHat

### DIFF
--- a/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
+++ b/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
@@ -144,13 +144,17 @@ public class RpmSignPlugin extends Recorder {
     try {
       writer.print("spawn ");
       writer.println(signCommand);
-      writer.println("expect \"Enter pass phrase: \"");
-      writer.print("send -- \"");
+      writer.println("expect {");
+      writer.print("-re \"Enter pass *phrase: *\" { log_user 0; send -- \"");
       writer.print(passphrase);
-      writer.println("\r\"");
-      writer.println("expect eof");
-      writer.println("catch wait rc");
-      writer.println("exit [lindex $rc 3]");
+      writer.println("\r\"; log_user 1; }");
+      writer.println("eof { catch wait rc; exit [lindex $rc 3]; }");
+      writer.println("timeout { close; exit; }");
+      writer.println("}");
+      writer.println("expect {");
+      writer.println("eof { catch wait rc; exit [lindex $rc 3]; }");
+      writer.println("timeout close");
+      writer.println("}");
       writer.println();
 
       writer.flush();

--- a/src/main/resources/jenkins/plugins/rpmsign/RpmSignPlugin/help-passphrase.html
+++ b/src/main/resources/jenkins/plugins/rpmsign/RpmSignPlugin/help-passphrase.html
@@ -1,0 +1,38 @@
+<div>Passphrase of the GPG key used for signing RPMs. This is kept in an encrypted form in the jenkins tree, and is only as secure as other encrypted passwords there.
+<p>
+As of RedHat rpm version 4.12.0.1-11 and gpg2 version 2.1 (first released in Fedora 22), rpm does not read the passphrase from stdin and pass it to gpg. On these systems some configuration is needed in order to pass the GPG key passphrase to rpm in an unattended manner.
+
+In the jenkin's user home directory, make the following modifications to .gnupg/gpg-agent.conf and .rpmmacros.
+
+<p>
+Add "allow-loopback-pinentry" option to gpg-agent:
+
+<pre>
+    echo "allow-loopback-pinentry" >> $HOME/.gnupg/gpg-agent.conf
+</pre>
+
+If the gpg-agent is running for the jenkins user, send it a HUP signal:
+<pre>
+    pkill -HUP gpg-agent
+</pre>
+
+Look at the default value of the RPM macro named "__gpg_sign_cmd" in /usr/lib/rpm/macros, or with rpm --eval:
+<pre>
+    rpm --eval "%__gpg_sign_cmd"
+</pre>
+
+Add  a "--pinentry-mode loopback" option to that macro in $HOME/.macros, as in this example for Fedora 22:
+
+<pre>
+    cat << \EOD >> $HOME/.rpmmacros
+%__gpg_sign_cmd %{__gpg} \
+    gpg --no-verbose --no-armor --pinentry-mode loopback \
+    %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
+    --no-secmem-warning \
+    -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
+EOD
+</pre>
+
+</div>
+
+


### PR DESCRIPTION
With the above version of rpm, the existing rpmsign plugin fails, and unfortunately will likely display the decoded passphrase in the build output.

From the change log of rpm version 4.12.0.1-11, the way passphrases are provided to gpg has changed::
- Allow gpg to get passphrase by itself (#1228234)

I've added updates to the expect script, and added a help-passphrase.html file, to give the user guidance on how to set things up so that jenkins can provide the passphrase.

I've tested this with new and old versions of RPM, so it should be backward compatible.