### PR TITLE
Expect buffer limit

### DIFF
--- a/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
+++ b/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.StringTokenizer;
 
+
 public class RpmSignPlugin extends Recorder {
 
   private List<Rpm> entries = Collections.emptyList();
@@ -37,6 +38,7 @@ public class RpmSignPlugin extends Recorder {
   private static final int EXPECT_BUFFER_SIZE = 4096;
 
   @DataBoundConstructor
+  @SuppressWarnings("unused")
   public RpmSignPlugin(List<Rpm> rpms) {
     this.entries = rpms;
     if (this.entries == null) {
@@ -49,12 +51,9 @@ public class RpmSignPlugin extends Recorder {
   }
 
   private boolean isPerformDeployment(AbstractBuild build) {
-    Result result = build.getResult();
-    if (result == null) {
-      return true;
-    }
+      Result result = build.getResult();
+      return result == null || result.isBetterOrEqualTo(Result.UNSTABLE);
 
-    return build.getResult().isBetterOrEqualTo(Result.UNSTABLE);
   }
 
   @SuppressWarnings("unused")

--- a/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
+++ b/src/main/java/jenkins/plugins/rpmsign/RpmSignPlugin.java
@@ -129,25 +129,25 @@ public class RpmSignPlugin extends Recorder {
     return true;
   }
 
-    private List<List<FilePath>> partitionRPMPackages(FilePath[] matchedRpms, PrintStream logger) {
+    private List<List<FilePath>> partitionRPMPackages(FilePath[] matchedRpms, PrintStream logger) throws IOException, InterruptedException {
         List<List<FilePath>> result = new ArrayList<List<FilePath>>();
 
         int currentSize = 0;
         List<FilePath> partition = new ArrayList<FilePath>();
         String packageName;
         for( FilePath rpmPackage : matchedRpms ){
-            packageName = rpmPackage.getName();
+            packageName = rpmPackage.toURI().normalize().getPath();
+
             if( packageName.length() > EXPECT_BUFFER_SIZE){
               logger.print("[RpmSignPlugin] - Cannot sign package, too long RPM path. Limit: "+ EXPECT_BUFFER_SIZE +"; Filename: "+packageName );
             } else {
               if (currentSize + packageName.length() > EXPECT_BUFFER_SIZE) {
-                result.add(partition);
+                  result.add(partition);
                 partition = new ArrayList<FilePath>();
                 currentSize = 0;
-              } else {
-                partition.add(rpmPackage);
-                currentSize += packageName.length();
               }
+              partition.add(rpmPackage);
+              currentSize += packageName.length();
             }
         }
 
@@ -177,7 +177,6 @@ public class RpmSignPlugin extends Recorder {
 
         return rpmSignCommand.toString();
     }
-
 
 
     private byte[] createExpectScriptFile(String signCommand, String passphrase)


### PR DESCRIPTION
When there is a lot of packages to sign or paths to workspaces are long, expect cannot take such long argument. The implementation that is subject of this PR is to create several rounds based on length of parameter. This solution is tested on production cluster more than half a year.
